### PR TITLE
Implement git repository for config changes

### DIFF
--- a/jvmctl/jvmctl/jvmctl.py
+++ b/jvmctl/jvmctl/jvmctl.py
@@ -656,6 +656,8 @@ def config(node):
         subprocess.check_call(['git', 'init'])
     subprocess.check_call(['git', 'add', node.config_file])
     if subprocess.call(['git', 'diff-index', '--quiet', 'HEAD']):
+        os.environ['GIT_COMMITTER_NAME'] = 'jvmctl'
+        os.environ['GIT_COMMITTER_EMAIL'] = 'root@'+os.uname()[1]
         subprocess.check_call(['git', 'commit', '--author="{0} <{0}@nla.gov.au>"'.format(os.getlogin()), '-m "Config change for {}"'.format(node.name)])
     return result
 

--- a/jvmctl/setup.cfg
+++ b/jvmctl/setup.cfg
@@ -1,3 +1,3 @@
 [bdist_rpm]
-requires=python-setuptools
+requires=python-setuptools,git
 

--- a/jvmctl/setup.py
+++ b/jvmctl/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "jvmctl",
-    version = "0.4.3",
+    version = "0.4.4",
     description = "Deploying and manage Java applications on EL7 servers",
     license = 'MIT',
     url = "https://github.com/nla/jvmctl",


### PR DESCRIPTION
Initial work on making jvmctl use a local git repository to store changes to config files for #20. Tries to label commits sanely and attribute them to the user running the command. This change adds a dependancy on git, though this was pretty much a soft dependancy already. 

Adds two new commands to jvmctl whose names I'm not completely sold on suggestions welcome
- changed --shows the most recent commit that matches the nodes name.   
- revert -- reverts the most recent commit that matches the nodes name

One flaw is that if a node's name is a subset of another node (say banjo and banjo-testing-foo) then the changed and revert commands aren't going to work as intended,  Maybe change the commit message to wrap node.name in something that cant be part of the name?
