### PR TITLE
Collect heap dump on out of memory error by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Option      | Default        | Description
 USER        | webapp         | unix account to run the application under
 JAVA_HOME   | /usr/lib/jvm/java-1.8.0 | path of the Java runtime to use
 JAVA_OPTS   |                | extra options to pass to java (system properties, GC options etc)
-HEAP_DUMP_OPTS | -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/tmp/${NODE}.hprof.tmp | heap dump jvm options
+HEAP_DUMP_PATH | /var/tmp/${NODE}.hprof | file or directory to store heap dumps
 HEAP_SIZE   | 128m           | amount of memory allocated to the jvm
 OOM_EMAIL   | root@localhost | address to email out of memory errors to
 EXEC_PREFIX |                | prefix to append to the executed command-line (use for wrapper scripts)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Option      | Default        | Description
 USER        | webapp         | unix account to run the application under
 JAVA_HOME   | /usr/lib/jvm/java-1.8.0 | path of the Java runtime to use
 JAVA_OPTS   |                | extra options to pass to java (system properties, GC options etc)
+HEAP_DUMP_OPTS | -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/tmp/${NODE}.hprof.tmp | heap dump jvm options
 HEAP_SIZE   | 128m           | amount of memory allocated to the jvm
 OOM_EMAIL   | root@localhost | address to email out of memory errors to
 EXEC_PREFIX |                | prefix to append to the executed command-line (use for wrapper scripts)

--- a/jvmctl/jvmctl/jvmctl.py
+++ b/jvmctl/jvmctl/jvmctl.py
@@ -766,6 +766,7 @@ def deploy(node):
     target = path.join(workarea, 'target')
     dest = node.apps_path
     pw = pwd.getpwnam('builder')
+    os.chdir('/') # workaround selinux permission problem when we switchuid
     env = dict(os.environ)
     pid = os.fork()
     if pid == 0:

--- a/jvmctl/jvmctl/jvmctl.py
+++ b/jvmctl/jvmctl/jvmctl.py
@@ -865,11 +865,11 @@ Heap dump: {heap_dump_file}
 
 
 def try_rename_heap_dump(node):
-    "Rename the heap dump file. Replacing any previous so we only keep the latest."
+    "Rename the temporary heap dump file. Replace any previous permanent dump file so we only keep the latest."
     try:
-        permfile = '/var/tmp/%s.hprof' % node.name
-        os.rename('/var/tmp/%s.hprof.tmp' % node.name, permfile)
-        return permfile
+        heap_dump_file = '/var/tmp/%s.hprof' % node.name
+        os.rename(heap_dump_file + '.tmp', heap_dump_file)
+        return heap_dump_file
     except OSError:
         return None
 


### PR DESCRIPTION
We only keep the latest dump for each application to avoid filling
up the disk if the application OOMs multiple times.

Can be disabled on per-JVM or per-server option by clearing
HEAP_DUMP_OPTS in the app config or in /etc/jvmctl.conf
respectively.