### PR TITLE
string decoding fix for rhel8

### DIFF
--- a/jvmctl/jvmctl/jvmctl.py
+++ b/jvmctl/jvmctl/jvmctl.py
@@ -499,7 +499,7 @@ class Node:
 
     def pid(self):
         process = subprocess.Popen(['systemctl', 'show', self.svc, '--property=MainPID'], stdout=subprocess.PIPE)
-        out = process.communicate()[0]
+        out = process.communicate()[0].decode("utf-8")
         retcode = process.poll()
         if retcode:
             return None


### PR DESCRIPTION
jvmctl list fails in rhel8 and python 3 with 

NODE                            VERSION   PORT  STATUS
Traceback (most recent call last):
  File "/usr/bin/jvmctl", line 11, in <module>
    load_entry_point('jvmctl==0.5.2', 'console_scripts', 'jvmctl')()
  File "/usr/lib/python3.6/site-packages/jvmctl/jvmctl.py", line 1055, in main
    list_nodes()
  File "/usr/lib/python3.6/site-packages/jvmctl/jvmctl.py", line 1027, in list_nodes
    pid = node.pid()
  File "/usr/lib/python3.6/site-packages/jvmctl/jvmctl.py", line 506, in pid
    return int(out.split('=')[1].strip())
TypeError: a bytes-like object is required, not 'str'

while it struggles to interpret the binary response from process.communicate(). This forces the encoding of the stdout object to utf8 so that it can be interpreted by the split method. Tested against python2 and it appears to respond as it should